### PR TITLE
Add examples for Custom Term End Date

### DIFF
--- a/sdk/SdkSamples/Orders/CreateOrder.cs
+++ b/sdk/SdkSamples/Orders/CreateOrder.cs
@@ -34,8 +34,11 @@ namespace Microsoft.Store.PartnerCenter.Samples.Orders
             string customerId = this.ObtainCustomerId("Enter the ID of the customer making the purchase");
             string offerId = this.ObtainOfferId("Enter the ID of the offer to purchase");
             
-            string termDuration = this.Context.ConsoleHelper.ReadNonEmptyString("Enter a term duration [example: P1Y, P1M]", "Term duration is required");
-            
+            string termDuration = this.Context.ConsoleHelper.ReadOptionalString("Enter a term duration [example: P1Y, P1M] if applicable");
+            if (!string.IsNullOrWhiteSpace(termDuration)) {
+                termDuration = null;
+            }
+                       
             string billingCycleString = this.ObtainBillingCycle("Enter a billing cycle [example: Annual or Monthly]");
             var billingCycle = (BillingCycleType)Enum.Parse(typeof(BillingCycleType), billingCycleString);
             

--- a/sdk/SdkSamples/Orders/CreateOrder.cs
+++ b/sdk/SdkSamples/Orders/CreateOrder.cs
@@ -36,10 +36,10 @@ namespace Microsoft.Store.PartnerCenter.Samples.Orders
             
             string termDuration = this.Context.ConsoleHelper.ReadNonEmptyString("Enter a term duration [example: P1Y, P1M]", "Term duration is required");
             
-            string billingCycleString = this.Context.ConsoleHelper.ReadNonEmptyString("Enter a billing cycle [example: Annual or Monthly]", "Billing cycle is required");
+            string billingCycleString = this.ObtainBillingCycle("Enter a billing cycle [example: Annual or Monthly]");
             var billingCycle = (BillingCycleType)Enum.Parse(typeof(BillingCycleType), billingCycleString);
             
-            string quantityString = this.Context.ConsoleHelper.ReadNonEmptyString("Enter a quantity", "Quantity is required");
+            string quantityString = this.ObtainQuantity();
             var quantity = int.Parse(quantityString);
             
             string customTermEndDateString = this.Context.ConsoleHelper.ReadOptionalString("Enter a custom term end date or leave blank to keep default");

--- a/sdk/SdkSamples/Orders/CreateOrder.cs
+++ b/sdk/SdkSamples/Orders/CreateOrder.cs
@@ -40,11 +40,11 @@ namespace Microsoft.Store.PartnerCenter.Samples.Orders
             var billingCycle = (BillingCycleType)Enum.Parse(typeof(BillingCycleType), billingCycleString);
             
             string quantityString = this.Context.ConsoleHelper.ReadNonEmptyString("Enter a quantity", "Quantity is required");
-            var quantity = int.Parse(quantity);
+            var quantity = int.Parse(quantityString);
             
             string customTermEndDateString = this.Context.ConsoleHelper.ReadOptionalString("Enter a custom term end date or leave blank to keep default");
             DateTime? customTermEndDate = null;
-            if (!string.IsNullOrWhiteSpace(customTermEndDate)) {
+            if (!string.IsNullOrWhiteSpace(customTermEndDateString)) {
                 customTermEndDate = DateTime.Parse(customTermEndDateString);
             }
             

--- a/sdk/SdkSamples/Orders/CreateOrder.cs
+++ b/sdk/SdkSamples/Orders/CreateOrder.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Store.PartnerCenter.Samples.Orders
 {
     using System;
     using System.Collections.Generic;
-    using Store.PartnerCenter.Models.Orders;
+    using Microsoft.Store.PartnerCenter.Models.Orders;
     using Microsoft.Store.PartnerCenter.Models.Offers;
 
     /// <summary>

--- a/sdk/SdkSamples/Orders/CreateOrder.cs
+++ b/sdk/SdkSamples/Orders/CreateOrder.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="CreateOrder.cs" company="Microsoft">
 //      Copyright (c) Microsoft Corporation.  All rights reserved.
 // </copyright>
@@ -6,8 +6,10 @@
 
 namespace Microsoft.Store.PartnerCenter.Samples.Orders
 {
+    using System;
     using System.Collections.Generic;
     using Store.PartnerCenter.Models.Orders;
+    using Microsoft.Store.PartnerCenter.Models.Offers;
 
     /// <summary>
     /// A scenario that creates a new order for a customer.

--- a/sdk/SdkSamples/Orders/CreateOrder.cs
+++ b/sdk/SdkSamples/Orders/CreateOrder.cs
@@ -32,6 +32,20 @@ namespace Microsoft.Store.PartnerCenter.Samples.Orders
             string customerId = this.ObtainCustomerId("Enter the ID of the customer making the purchase");
             string offerId = this.ObtainOfferId("Enter the ID of the offer to purchase");
             
+            string termDuration = this.Context.ConsoleHelper.ReadNonEmptyString("Enter a term duration [example: P1Y, P1M]", "Term duration is required");
+            
+            string billingCycleString = this.Context.ConsoleHelper.ReadNonEmptyString("Enter a billing cycle [example: Annual or Monthly]", "Billing cycle is required");
+            var billingCycle = (BillingCycleType)Enum.Parse(typeof(BillingCycleType), billingCycleString);
+            
+            string quantityString = this.Context.ConsoleHelper.ReadNonEmptyString("Enter a quantity", "Quantity is required");
+            var changeToQuantity = int.Parse(quantity);
+            
+            string customTermEndDateString = this.Context.ConsoleHelper.ReadOptionalString("Enter a custom term end date or leave blank to keep default");
+            DateTime? customTermEndDate = null;
+            if (!string.IsNullOrWhiteSpace(customTermEndDate)) {
+                customTermEndDate = DateTime.Parse(customTermEndDateString);
+            }
+            
             var order = new Order()
             {
                 ReferenceCustomerId = customerId,

--- a/sdk/SdkSamples/Orders/CreateOrder.cs
+++ b/sdk/SdkSamples/Orders/CreateOrder.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Store.PartnerCenter.Samples.Orders
             string offerId = this.ObtainOfferId("Enter the ID of the offer to purchase");
             
             string termDuration = this.Context.ConsoleHelper.ReadOptionalString("Enter a term duration [example: P1Y, P1M] if applicable");
-            if (!string.IsNullOrWhiteSpace(termDuration)) {
+            if (string.IsNullOrWhiteSpace(termDuration)) {
                 termDuration = null;
             }
                        

--- a/sdk/SdkSamples/Orders/CreateOrder.cs
+++ b/sdk/SdkSamples/Orders/CreateOrder.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Store.PartnerCenter.Samples.Orders
             var billingCycle = (BillingCycleType)Enum.Parse(typeof(BillingCycleType), billingCycleString);
             
             string quantityString = this.Context.ConsoleHelper.ReadNonEmptyString("Enter a quantity", "Quantity is required");
-            var changeToQuantity = int.Parse(quantity);
+            var quantity = int.Parse(quantity);
             
             string customTermEndDateString = this.Context.ConsoleHelper.ReadOptionalString("Enter a custom term end date or leave blank to keep default");
             DateTime? customTermEndDate = null;
@@ -49,13 +49,16 @@ namespace Microsoft.Store.PartnerCenter.Samples.Orders
             var order = new Order()
             {
                 ReferenceCustomerId = customerId,
+                BillingCycle = billingCycle,
                 LineItems = new List<OrderLineItem>()
                 {
                     new OrderLineItem()
                     {
                         OfferId = offerId,
                         FriendlyName = "new offer purchase",
-                        Quantity = 5
+                        Quantity = quantity,
+                        TermDuration = termDuration,
+                        CustomTermEndDate = customTermEndDate
                     }
                 }
             };

--- a/sdk/SdkSamples/Subscriptions/UpdateSubscriptionScheduledChange.cs
+++ b/sdk/SdkSamples/Subscriptions/UpdateSubscriptionScheduledChange.cs
@@ -83,10 +83,18 @@ namespace Microsoft.Store.PartnerCenter.Samples.Subscriptions
                     // prompt the user to enter the term duration for the scheduled change
                     string changeToTermDuration = this.Context.ConsoleHelper.ReadNonEmptyString("Enter the scheduled change term duration", "Scheduled change term duration can't be empty");
 
-                    // prompt the user to enter the term duration for the scheduled change
+                    // prompt the user to enter the quantity for the scheduled change
                     string quantity = this.Context.ConsoleHelper.ReadNonEmptyString("Enter the scheduled change quantity", "Scheduled change term quantity can't be empty");
                     var changeToQuantity = int.Parse(quantity);
-
+                    
+                    // prompt the user to enter the custom term end date for the scheduled change
+                    string customTermEndDate = this.Context.ConsoleHelper.ReadOptionalString("Enter the scheduled change custom term end date or leave blank to keep the current term end date");
+                    DateTime? changeToCustomTermEndDate = null;
+                    
+                    if (!string.IsNullOrWhiteSpace(customTermEndDate)) {
+                        changeToCustomTermEndDate = DateTime.Parse(customTermEndDate);
+                    }
+                    
                     this.Context.ConsoleHelper.StartProgress("Updating subscription scheduled change");
                     selectedSubscription.ScheduledNextTermInstructions = new ScheduledNextTermInstructions
                     {
@@ -99,6 +107,7 @@ namespace Microsoft.Store.PartnerCenter.Samples.Subscriptions
                             TermDuration = changeToTermDuration,
                         },
                         Quantity = changeToQuantity,
+                        CustomTermEndDate = changeToCustomTermEndDate,
                     };
 
                     var updatedSubscription = subscriptionOperations.Patch(selectedSubscription);

--- a/sdk/SdkSamples/Subscriptions/UpdateSubscriptionScheduledChange.cs
+++ b/sdk/SdkSamples/Subscriptions/UpdateSubscriptionScheduledChange.cs
@@ -107,7 +107,7 @@ namespace Microsoft.Store.PartnerCenter.Samples.Subscriptions
                             TermDuration = changeToTermDuration,
                         },
                         Quantity = changeToQuantity,
-                        CustomTermEndDate = changeToCustomTermEndDate,
+                        CustomTermEndDate = changeToCustomTermEndDate
                     };
 
                     var updatedSubscription = subscriptionOperations.Patch(selectedSubscription);


### PR DESCRIPTION
# Description

Please add a meaningful description for this change. Ensure the PR has required unit tests.

Adding the custom term end date field to renewal and purchase scenarios.

## Related issue

Kindly link any related issues (e.g. Fixes #xyz).